### PR TITLE
add docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ COPY . /app/
 # Expose the port that FastAPI will listen on (if your app is using a different port, change it here)
 EXPOSE 8000
 
-# Run the FastAPI application using uvicorn
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run the FastAPI application (uvicorn is launched from main.py)
+CMD ["python", "/app/main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+
+services:
+
+  cheshire-cat-awesome-plugins-backend:
+    build:
+      context: .
+    container_name: cheshire_cat_awesome_plugins_backend
+    ports:
+      - 8000:8000
+    volumes:
+      - ./:/app
+    command:
+      - python
+      - "/app/main.py"
+    restart: unless-stopped


### PR DESCRIPTION
Added a docker-compose.yml to avoid launching long docker commands.
Both the `Dockerfile` and the `docker-compose.yml` launch `main.py` as uvicorn is launched from the `__main__` in that script.

