### PR TITLE
Plugin html table endpoint added

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,28 @@ Return an HTML webpage with an image of plugins' analytics graph.
 
 ---  
 
+### Get Plugins HTML Page
+
+**GET** `/plugins_table`
+
+Get an html page containing all plugins.
+
+**Optional Parameters:**
+
+- `columns`: A comma separated list of fields that will be filtered. Possible values are: "name", "description" "author_name", "author_url", "plugin_url", "tags", "thumb", "version", "url", "downloads" - default is **all** fields shown inside table
+- `render_link`: If `True` will transform URL into hyperlynks - default is `False`
+- `classes`: Add css classes on `<table>` element - default is "plugins-table"
+
+
+Example: Show only `name` `plugin_url` and `author_name`, use hyperlynks and add `foo` as css class:
+
+
+```plaintext
+/plugins_table?columns=name,plugin_url,author_name&render_link=True&classes=foo
+```
+
+---
+
 ## Plugin manifest validation
 
 The validation process for the plugin.json manifest ensures the integrity and usability of plugins within the repository. 

--- a/plugins_html_table.py
+++ b/plugins_html_table.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from fastapi import HTTPException
+
+PLUGIN_COLUMNS = [
+    "name",
+    "description",
+    "author_name",
+    "author_url",
+    "plugin_url",
+    "tags",
+    "thumb",
+    "version",
+    "url",
+    "downloads"
+]
+
+def generate_plugins_html_table(plugins, columns: str = ",".join(PLUGIN_COLUMNS), render_link: bool = False, classes: str = "plugins-table"):
+    splitted_columns = columns.split(",")
+    for column in splitted_columns:
+        if column not in PLUGIN_COLUMNS:
+            raise HTTPException(status_code=406, detail=f"'column' field: {column} not valid. Valid fields: {PLUGIN_COLUMNS}")
+
+    df = pd.DataFrame(plugins)
+    df = df.filter(splitted_columns)
+    return df.to_html(index=False, render_links=render_link, classes=classes)


### PR DESCRIPTION
This endpoint allow to download a plugin list as html table

the following **optional** parameters are supported:

* `columns`: a comma-separated list of fields, default fields are: `['name', 'description', 'author_name', 'author_url', 'plugin_url', 'tags', 'thumb', 'version', 'url', 'downloads']`
* `render_link`: whether or not transform url into hyperlinks, default is False
* `classes`: css classes that will be applied into <table> element, default is 'plugins-table'
